### PR TITLE
Add support for Inline Fragments, return relations as a Set

### DIFF
--- a/src/RelationMapper.spec.ts
+++ b/src/RelationMapper.spec.ts
@@ -7,6 +7,7 @@ import { Owner } from '../test/entities/owner';
 import { Store } from '../test/entities/store';
 import { Image } from '../test/entities/image';
 import { ImageFile } from '../test/entities/imagefile';
+import { Video } from '../test/entities/video';
 import { resolvers, typeDefs } from '../test/schema';
 import { insertMockData, TestMockData } from '../test/data';
 
@@ -20,7 +21,7 @@ describe('RelationMapper', () => {
     connection = await createConnection({
       type: 'sqlite',
       database: 'test/test.sqlite',
-      entities: [Product, Owner, Store, Image, ImageFile],
+      entities: [Product, Owner, Store, Image, ImageFile, Video],
       synchronize: true,
       dropSchema: true,
     });

--- a/src/RelationMapper.spec.ts
+++ b/src/RelationMapper.spec.ts
@@ -62,7 +62,7 @@ describe('RelationMapper', () => {
       const resolveInfoHook = (info: GraphQLResolveInfo): void => {
         const relations = new RelationMapper(connection).buildRelationListForQuery(Product, info);
 
-        expect(relations).toEqual(['owner', 'store']);
+        expect([...relations]).toEqual(['owner', 'store']);
       };
       const result = await graphql(executableSchema, query, {}, { resolveInfoHook });
 
@@ -115,7 +115,7 @@ describe('RelationMapper', () => {
       const resolveInfoHook = (info: GraphQLResolveInfo): void => {
         const relations = new RelationMapper(connection).buildRelationListForQuery(Product, info);
 
-        expect(relations).toEqual(['owner', 'store', 'store.owner']);
+        expect([...relations]).toEqual(['owner', 'store', 'store.owner']);
       };
       const result = await graphql(executableSchema, query, {}, { resolveInfoHook });
 
@@ -184,7 +184,7 @@ describe('RelationMapper', () => {
       const resolveInfoHook = (info: GraphQLResolveInfo): void => {
         const relations = new RelationMapper(connection).buildRelationListForQuery(Product, info);
 
-        expect(relations).toEqual(['owner', 'store', 'store.owner']);
+        expect([...relations]).toEqual(['owner', 'store', 'store.owner']);
       };
       const result = await graphql(executableSchema, query, {}, { resolveInfoHook });
 
@@ -254,7 +254,7 @@ describe('RelationMapper', () => {
       const resolveInfoHook = (info: GraphQLResolveInfo): void => {
         const relations = new RelationMapper(connection).buildRelationListForQuery(Product, info);
 
-        expect(relations).toEqual([]);
+        expect([...relations]).toEqual([]);
       };
       const result = await graphql(executableSchema, query, {}, { resolveInfoHook });
 

--- a/src/RelationMapper.ts
+++ b/src/RelationMapper.ts
@@ -157,6 +157,26 @@ export class RelationMapper {
   }
 
   private findFieldInSelection(fieldName: string, selectionSet: SelectionSetNode): SelectionNode | undefined {
-    return selectionSet.selections.find(selectionNode => this.getNameFromNode(selectionNode) === fieldName);
+    let foundNode: SelectionNode | undefined = undefined;
+
+    for (const selectionNode of selectionSet.selections) {
+      if (foundNode !== undefined) {
+        break;
+      }
+
+      if (selectionNode.kind === 'InlineFragment') {
+        foundNode = this.findFieldInSelection(fieldName, selectionNode.selectionSet);
+
+        break;
+      }
+
+      if (this.getNameFromNode(selectionNode) === fieldName) {
+        foundNode = selectionNode;
+
+        break;
+      }
+    }
+
+    return foundNode;
   }
 }

--- a/src/RelationMapper.ts
+++ b/src/RelationMapper.ts
@@ -41,7 +41,8 @@ export class RelationMapper {
       let currentPropertyPath = basePropertyPath;
 
       // find relation metadata, if field corresponds to a relation property
-      const relationMetadata = this.findRelationMetadata(nodeName, entity);
+      // note: nodeName will be null if current node is an inline fragment, in that case we just continue recursion
+      const relationMetadata = nodeName != null ? this.findRelationMetadata(nodeName, entity) : undefined;
 
       if (relationMetadata != null) {
         // build up relation path by appending current property name
@@ -125,13 +126,13 @@ export class RelationMapper {
     return this.getRelationsMetadata(entity).find(relationMetadata => relationMetadata.propertyName === nodeName);
   }
 
-  private getNameFromNode(selectionNode: SelectionNode): string {
+  private getNameFromNode(selectionNode: SelectionNode): string | null {
     switch (selectionNode.kind) {
       case 'Field':
       case 'FragmentSpread':
         return selectionNode.name.value;
       case 'InlineFragment':
-        throw new Error('Cannot get node name for an InlineFragment.');
+        return null;
     }
   }
 
@@ -147,9 +148,8 @@ export class RelationMapper {
 
         return fragments[selectionNode.name.value].selectionSet;
       case 'Field':
-        return selectionNode.selectionSet;
       case 'InlineFragment':
-        throw new Error('Support for InlineFragment nodes has not been implemented.'); // TODO: implement InlineFragment support
+        return selectionNode.selectionSet;
     }
   }
 

--- a/src/RelationMapper.ts
+++ b/src/RelationMapper.ts
@@ -9,7 +9,10 @@ export class RelationMapper {
    * Build the list of matching TypeORM relation property names for an entity, based on the `info` given to a GraphQL
    * query resolver.
    */
-  public buildRelationListForQuery(entity: Function | EntitySchema<any> | string, info: GraphQLResolveInfo): string[] {
+  public buildRelationListForQuery(
+    entity: Function | EntitySchema<any> | string,
+    info: GraphQLResolveInfo,
+  ): Set<string> {
     const baseNode = info.fieldNodes.find(fieldNode => fieldNode.name.value === info.fieldName);
 
     if (baseNode == null) {
@@ -27,8 +30,8 @@ export class RelationMapper {
     baseNode: SelectionNode,
     fragments?: { [p: string]: FragmentDefinitionNode },
     basePropertyPath?: string,
-  ): string[] {
-    const relationNames: string[] = [];
+  ): Set<string> {
+    const relationNames = new Set<string>();
     const selectionSet = this.getSelectionSetFromNode(baseNode, fragments);
 
     if (selectionSet == null) {
@@ -51,7 +54,7 @@ export class RelationMapper {
           : relationMetadata.propertyName;
 
         // add the relation to the list
-        relationNames.push(currentPropertyPath);
+        relationNames.add(currentPropertyPath);
       }
 
       /*
@@ -66,7 +69,7 @@ export class RelationMapper {
         fragments,
         currentPropertyPath,
       );
-      relationNames.push(...nestedRelations);
+      nestedRelations.forEach(nestedRelation => relationNames.add(nestedRelation));
     });
 
     return relationNames;

--- a/test/data.ts
+++ b/test/data.ts
@@ -2,37 +2,81 @@ import { Connection } from 'typeorm';
 import { Owner } from './entities/owner';
 import { Store } from './entities/store';
 import { Product } from './entities/product';
+import { Video } from './entities/video';
+import { Image } from './entities/image';
+import { ImageFile } from './entities/imagefile';
 
 export interface TestMockData {
   ownerA: Owner;
   storeA: Store;
   productA: Product;
+  imageA: Image;
+  videoA: Video;
 }
 
 export const insertMockData = async (connection: Connection): Promise<TestMockData> => {
   const ownerRepo = connection.getRepository(Owner);
   const storeRepo = connection.getRepository(Store);
   const productRepo = connection.getRepository(Product);
+  const imageRepo = connection.getRepository(Image);
+  const imageFileRepo = connection.getRepository(ImageFile);
+  const videoRepo = connection.getRepository(Video);
 
-  const ownerA = ownerRepo.create({ name: 'Owner A' });
-  await ownerRepo.save(ownerA);
+  // OWNERS
+  const ownerA = await ownerRepo.save(ownerRepo.create({ name: 'Owner A' }));
 
-  const storeA = storeRepo.create({
-    name: 'Store A',
-    owner: ownerA,
-  });
-  await storeRepo.save(storeA);
+  // STORES
+  const storeA = await storeRepo.save(
+    storeRepo.create({
+      name: 'Store A',
+      owner: ownerA,
+    }),
+  );
 
-  const productA = productRepo.create({
-    name: 'Product A',
-    owner: ownerA,
-    store: storeA,
-  });
-  await productRepo.save(productA);
+  // PRODUCTS
+  const productA = await productRepo.save(
+    productRepo.create({
+      name: 'Product A',
+      owner: ownerA,
+      store: storeA,
+    }),
+  );
+
+  // IMAGES
+  const imageA = await imageRepo.save(
+    imageRepo.create({
+      sizeSmall: await imageFileRepo.save(
+        imageFileRepo.create({
+          fileName: 'small.jpg',
+        }),
+      ),
+      sizeMedium: await imageFileRepo.save(
+        imageFileRepo.create({
+          fileName: 'medium.jpg',
+        }),
+      ),
+      sizeLarge: await imageFileRepo.save(
+        imageFileRepo.create({
+          fileName: 'large.jpg',
+        }),
+      ),
+      product: productA,
+    }),
+  );
+
+  // VIDEOS
+  const videoA = await videoRepo.save(
+    videoRepo.create({
+      duration: 123,
+      product: productA,
+    }),
+  );
 
   return {
     ownerA,
     storeA,
     productA,
+    imageA,
+    videoA,
   };
 };

--- a/test/entities/image.ts
+++ b/test/entities/image.ts
@@ -1,5 +1,6 @@
 import { Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { ImageFile } from './imagefile';
+import { Product } from './product';
 
 @Entity()
 export class Image {
@@ -14,6 +15,9 @@ export class Image {
 
   @ManyToOne(_type => ImageFile)
   public sizeLarge: ImageFile;
+
+  @ManyToOne(_type => Product)
+  public product: Product;
 }
 
 export interface ImageSizeMap {

--- a/test/entities/product.ts
+++ b/test/entities/product.ts
@@ -1,7 +1,9 @@
-import { Entity, Column, PrimaryGeneratedColumn, ManyToOne, ManyToMany } from 'typeorm';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Owner } from './owner';
 import { Store } from './store';
 import { Image } from './image';
+import { Video } from './video';
+import { OneToMany } from 'typeorm/index';
 
 @Entity()
 export class Product {
@@ -17,6 +19,9 @@ export class Product {
   @ManyToOne(_type => Store)
   public store: Store;
 
-  @ManyToMany(_type => Image)
+  @OneToMany(_type => Image, image => image.product)
   public images: Image[];
+
+  @OneToMany(_type => Video, video => video.product)
+  public videos: Video[];
 }

--- a/test/entities/video.ts
+++ b/test/entities/video.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { ManyToOne } from 'typeorm/index';
+import { Product } from './product';
+
+@Entity()
+export class Video {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @Column()
+  public duration: number;
+
+  @ManyToOne(_type => Product)
+  public product: Product;
+}

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -4,6 +4,7 @@ import { getConnection } from 'typeorm';
 import { Product } from './entities/product';
 import { Image, ImageSizeMap } from './entities/image';
 import { RelationMapper } from '../src';
+import { Video } from './entities/video';
 
 export interface TestResolverContext {
   resolveInfoHook: (info: GraphQLResolveInfo) => void;
@@ -22,6 +23,8 @@ export const typeDefs = `
     owner: Owner
     store: Store
     images: [Image!]
+    videos: [Video!]
+    media: [MediaTypeUnion!]
   }
 
   type Store {
@@ -33,6 +36,7 @@ export const typeDefs = `
   type Image {
     id: Int!
     sizes: ImageSizeMap
+    product: Product!
   }
 
   type ImageFile {
@@ -45,6 +49,14 @@ export const typeDefs = `
     medium: ImageFile
     large: ImageFile
   }
+
+  type Video {
+    id: Int!
+    duration: Int!
+    product: Product!
+  }
+
+  union MediaTypeUnion = Image | Video
 
   type Query {
     products: [Product]!
@@ -61,19 +73,61 @@ export const resolvers: IResolvers<any, TestResolverContext> = {
       context.resolveInfoHook(info);
 
       const connection = getConnection();
+      const productRelations = new RelationMapper(connection).buildRelationListForQuery(Product, info);
 
       return connection.getRepository(Product).find({
-        relations: new RelationMapper(connection).buildRelationListForQuery(Product, info),
+        relations: productRelations,
       });
     },
   },
   Image: {
-    sizes(source: Image, args: any, context: TestResolverContext, info: GraphQLResolveInfo): ImageSizeMap {
+    sizes(source: Image): ImageSizeMap {
       return {
         small: source.sizeSmall,
         medium: source.sizeMedium,
         large: source.sizeLarge,
       };
+    },
+  },
+  Product: {
+    async media(
+      source: Product,
+      args: any,
+      context: TestResolverContext,
+      info: GraphQLResolveInfo,
+    ): Promise<(Image | Video)[]> {
+      const connection = getConnection();
+
+      const imageRelations = new RelationMapper(connection).buildRelationListForQuery(Image, info);
+      const videoRelations = new RelationMapper(connection).buildRelationListForQuery(Video, info);
+
+      const images = await connection.getRepository(Image).find({
+        where: {
+          product: source,
+        },
+        relations: imageRelations,
+      });
+      const videos = await connection.getRepository(Video).find({
+        where: {
+          product: source,
+        },
+        relations: videoRelations,
+      });
+
+      return [...images, ...videos];
+    },
+  },
+  MediaTypeUnion: {
+    __resolveType(value: Image | Video): 'Image' | 'Video' | null {
+      if (value instanceof Image) {
+        return 'Image';
+      }
+
+      if (value instanceof Video) {
+        return 'Video';
+      }
+
+      return null;
     },
   },
 };

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -98,8 +98,22 @@ export const resolvers: IResolvers<any, TestResolverContext> = {
     ): Promise<(Image | Video)[]> {
       const connection = getConnection();
 
-      const imageRelations = new RelationMapper(connection).buildRelationListForQuery(Image, info);
-      const videoRelations = new RelationMapper(connection).buildRelationListForQuery(Video, info);
+      const mapper = new RelationMapper(connection);
+      const imageRelations = mapper.buildRelationListForQuery(Image, info);
+      const videoRelations = mapper.buildRelationListForQuery(Video, info);
+
+      // TODO: these kind of relations can't be mapped automatically yet
+      if (mapper.isFieldSelected('sizes.small', info)) {
+        imageRelations.add('sizeSmall');
+      }
+
+      if (mapper.isFieldSelected('sizes.medium', info)) {
+        imageRelations.add('sizeMedium');
+      }
+
+      if (mapper.isFieldSelected('sizes.large', info)) {
+        imageRelations.add('sizeLarge');
+      }
 
       const images = await connection.getRepository(Image).find({
         where: {

--- a/test/schema.ts
+++ b/test/schema.ts
@@ -76,7 +76,7 @@ export const resolvers: IResolvers<any, TestResolverContext> = {
       const productRelations = new RelationMapper(connection).buildRelationListForQuery(Product, info);
 
       return connection.getRepository(Product).find({
-        relations: productRelations,
+        relations: [...productRelations],
       });
     },
   },
@@ -105,13 +105,13 @@ export const resolvers: IResolvers<any, TestResolverContext> = {
         where: {
           product: source,
         },
-        relations: imageRelations,
+        relations: [...imageRelations],
       });
       const videos = await connection.getRepository(Video).find({
         where: {
           product: source,
         },
-        relations: videoRelations,
+        relations: [...videoRelations],
       });
 
       return [...images, ...videos];


### PR DESCRIPTION
- Enables parsing of Inline Fragments in selection sets.
- Does not enable automatic relation mapping for union types as this is too hard for now.