### PR TITLE
Handle `FragmentSpread` selections nested inside `InlineFragment` nodes

### DIFF
--- a/src/RelationMapper.ts
+++ b/src/RelationMapper.ts
@@ -122,7 +122,7 @@ export class RelationMapper {
         return;
       }
 
-      const foundNode = this.findFieldInSelection(fieldName, selectionSet);
+      const foundNode = this.findFieldInSelection(fieldName, selectionSet, info.fragments);
 
       if (foundNode == null) {
         fieldPathNodes.push(null);
@@ -186,7 +186,11 @@ export class RelationMapper {
     }
   }
 
-  private findFieldInSelection(fieldName: string, selectionSet: SelectionSetNode): SelectionNode | undefined {
+  private findFieldInSelection(
+    fieldName: string,
+    selectionSet: SelectionSetNode,
+    fragments?: Record<string, FragmentDefinitionNode>,
+  ): SelectionNode | undefined {
     let foundNode: SelectionNode | undefined = undefined;
 
     for (const selectionNode of selectionSet.selections) {
@@ -194,8 +198,14 @@ export class RelationMapper {
         break;
       }
 
-      if (selectionNode.kind === 'InlineFragment') {
-        foundNode = this.findFieldInSelection(fieldName, selectionNode.selectionSet);
+      if (selectionNode.kind === 'InlineFragment' || selectionNode.kind === 'FragmentSpread') {
+        const selectionSet = this.getSelectionSetFromNode(selectionNode, fragments);
+
+        if (selectionSet === undefined) {
+          break;
+        }
+
+        foundNode = this.findFieldInSelection(fieldName, selectionSet, fragments);
 
         break;
       }


### PR DESCRIPTION
This fixes an issue where selections represented by a named fragment (written like `...FragmentName`) that were nested within an inline fragment (e.g. a union or interface type, written like `... on Image { ... }`) could not be traversed correctly.

This didn't work because `RelationMapper.findFieldInSelection()` tried to get the selection set directly from the node, but in this scenario the selection set has to be cross referenced back to the named fragment.